### PR TITLE
#7 AWS CLI bash script bug fix, the bug was fixed after a short break and some further investigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,4 +166,4 @@ If successful, a json payload should be rerturned that looks like this.
 
 We will need to generate AWS credentials in order to use the AWS CLI.
 
-#### bug magically fixed itself 
+ 


### PR DESCRIPTION
After a little investigation and a short break with a few environment refreshes the bug seemed to fix itself, the install_aws_cli bash scripts now running on startup.