### PR TITLE
#38 Invalidate Cloudfront Stack when content version changes

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -23,3 +23,22 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:f8d2d2bba1b8b3c7885e743e67beddf7045ee4d14048d50c5769574db4b25680",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.1"
+  hashes = [
+    "h1:FbGfc+muBsC17Ohy5g806iuI1hQc4SIexpYCrQHQd8w=",
+    "zh:58ed64389620cc7b82f01332e27723856422820cfd302e304b5f6c3436fb9840",
+    "zh:62a5cc82c3b2ddef7ef3a6f2fedb7b9b3deff4ab7b414938b08e51d6e8be87cb",
+    "zh:63cff4de03af983175a7e37e52d4bd89d990be256b16b5c7f919aff5ad485aa5",
+    "zh:74cb22c6700e48486b7cabefa10b33b801dfcab56f1a6ac9b6624531f3d36ea3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79e553aff77f1cfa9012a2218b8238dd672ea5e1b2924775ac9ac24d2a75c238",
+    "zh:a1e06ddda0b5ac48f7e7c7d59e1ab5a4073bbcf876c73c0299e4610ed53859dc",
+    "zh:c37a97090f1a82222925d45d84483b2aa702ef7ab66532af6cbcfb567818b970",
+    "zh:e4453fbebf90c53ca3323a92e7ca0f9961427d2f0ce0d2b65523cc04d5d999c2",
+    "zh:e80a746921946d8b6761e77305b752ad188da60688cfd2059322875d363be5f5",
+    "zh:fbdb892d9822ed0e4cb60f2fedbdbb556e4da0d88d3b942ae963ed6ff091e48f",
+    "zh:fca01a623d90d0cad0843102f9b8b9fe0d3ff8244593bd817f126582b52dd694",
+  ]
+}

--- a/journal/week1.md
+++ b/journal/week1.md
@@ -267,7 +267,7 @@ resource "aws_s3_object" "index_html" {
 
 ## Terraform Locals 
 
-Locals allow us to define local variables and it can be very useful when we need to transform data into another format and have refrenced a variable
+Locals allow us to define local variables and it can be very useful when we need to transform data into another format and have refrenced a variable.
 
 [Local Values](https://developer.hashicorp.com/terraform/language/values/locals)
 
@@ -295,7 +295,7 @@ https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/b
 
 ## Working with JSON
 
-We used the jsonencode to create the json policy inline in the hcl
+We used the jsonencode to create the json policy inline in the hcl.
 
 ```js
   jsonencode({"hello"="world"})
@@ -313,3 +313,54 @@ We used the jsonencode to create the json policy inline in the hcl
 Plain data values such as Local Values and Input Variables don't have any side-effects to plan against and so they aren't valid in replace_triggered_by. You can use terraform_data's behavior of planning an action each time input changes to indirectly use a plain value to trigger replacement.
 
 [Terraform Data](https://developer.hashicorp.com/terraform/language/resources/terraform-data)
+
+## Provisioners 
+
+Provisioners allow you to execute commands on compute intances e.g. a AWS CLI command. 
+
+They are not recommended for use by Hashicorp because configuration management tools such as Ansible are a better fir, but the functionality exists. 
+
+[Provisioners](https://developer.hashicorp.com/terraform/language/resources/provisioners/syntax)
+
+### Local-exec
+
+This will execute a command on the machine runnig the terraform commands e.g. plan apply. 
+
+```t
+resource "aws_instance" "web" {
+
+  provisioner "local-exec" {
+    command    = "echo The server's IP address is ${self.private_ip}"
+    on_failure = continue
+  }
+}
+```
+
+[Local](https://developer.hashicorp.com/terraform/language/resources/provisioners/local-exec)
+
+### Remote-exec
+
+This will execute commands on a machine which yu target. You will need to provide credentials such as ssh to get into the machine.
+
+```t
+resource "aws_instance" "web" {
+  # ...
+
+  # Establishes connection to be used by all
+  # generic remote provisioners (i.e. file/remote-exec)
+  connection {
+    type     = "ssh"
+    user     = "root"
+    password = var.root_password
+    host     = self.public_ip
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "puppet apply",
+      "consul join ${aws_instance.web.private_ip}",
+    ]
+  }
+}
+```
+[Remote](https://developer.hashicorp.com/terraform/language/resources/provisioners/remote-exec)

--- a/modules/terrahouse_aws/outputs.tf
+++ b/modules/terrahouse_aws/outputs.tf
@@ -5,3 +5,7 @@ output "bucket_name" {
 output "website_endpoint" {
    value = aws_s3_bucket.website_bucket
 }
+
+output "cloudfront_url" {
+  value = aws_cloudfront_distribution.s3_distribution.domain_name
+}

--- a/modules/terrahouse_aws/resource-cdn.tf
+++ b/modules/terrahouse_aws/resource-cdn.tf
@@ -72,3 +72,17 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     cloudfront_default_certificate = true
   }
 }
+
+resource "null_resource" "invalidate_cache" {
+  triggers = {
+    content_version = "${terraform.workspace}"
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      aws cloudfront create-invalidation \
+        --distribution-id ${aws_cloudfront_distribution.s3_distribution.id} \
+        --paths "/*"
+    EOT
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,8 @@ output "website_endpoint" {
     description = "s3 static website hosting endpoint" 
     value = module.terrahouse_aws.website_endpoint
 }
+
+output "cloudfront_url" {
+    description = "The CloudFront Distribution Domain Name"
+    value = module.terrahouse_aws.cloudfront_url
+}

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
     <title>Hello Terraformers</title>
 </head>
 <body>
-    <h1>Hello Terraformers!!!!!</h1>
+    <h1>Hello Transformers!!!!!</h1>
     <p>This is a simple HTML page with a heading.</p>
 </body>
 </html>


### PR DESCRIPTION
Now the stack is invalidated when the version changes, which is great for small projects. However, tools like Ansible would be used on larger projects, and the journals updated to reflect this.